### PR TITLE
Add Cortex - AI Memory Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Agent Skills are portable, [open standard](https://agentskills.io/home), version
 
 - [Calculator](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/calculator/SKILL.md) - Performs arbitrary-precision arithmetic calculations including addition, subtraction, multiplication, division, and exponents.
 - [Jira CLI](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/jira-cli/SKILL.md) - Interact with Jira from the command line to create, list, view, edit, and transition issues, manage sprints and epics, and perform common Jira workflows.
+- [Cortex](https://github.com/SKULLFIRE07/cortex-memory) - Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context. 3-layer memory (working/episodic/semantic). VSCode extension + CLI + MCP server. Free.
 
 ### Documents
 


### PR DESCRIPTION
Cortex gives AI coding assistants persistent memory across sessions.

- GitHub: https://github.com/SKULLFIRE07/cortex-memory
- Marketplace: https://marketplace.visualstudio.com/items?itemName=cortex-dev.cortex-ai-memory
- MIT licensed