### PR TITLE
Add Code Tour skill to Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Agent Skills are portable, [open standard](https://agentskills.io/home), version
 
 ### Development
 
+- [Code Tour](https://github.com/vaddisrinivas/code-tour) - AI-generated CodeTour walkthroughs for any codebase. Creates persona-targeted .tour files with step-by-step explanations linked to real files and line numbers.
 - [Playwright CLI](https://github.com/microsoft/playwright-cli/blob/main/skills/playwright-cli/SKILL.md) - Automate browser interactions, test web pages and work with Playwright tests.
 - [Frontend Design](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) - Create distinctive, production-grade frontend interfaces with high design quality.
 - [Webapp Testing](https://github.com/anthropics/skills/blob/main/skills/webapp-testing/SKILL.md) - Toolkit for interacting with and testing local web applications using Playwright.


### PR DESCRIPTION
Adds [Code Tour](https://github.com/vaddisrinivas/code-tour) to the **Agent Skills > Development** section.

**What it does:** AI-generated CodeTour walkthroughs for any codebase. Creates persona-targeted `.tour` files with step-by-step explanations linked to real files and line numbers. Supports 20 developer personas and all CodeTour step types.

This is an agent skill following the [open standard](https://agentskills.io/home) format with a SKILL.md, bundled scripts, and persona definitions.

**Install:** `npx skills add vaddisrinivas/code-tour`