### PR TITLE
Add SidClaw governance MCP to Governance & Security MCPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ This section highlights useful MCP servers you can add to your Copilot setup to 
 - [Playwright](https://github.com/microsoft/playwright-mcp) - Playwright MCP to automate browser interactions, test web pages and work with Playwright tests.
 - [Context7](https://github.com/upstash/context7) - Inject version-specific code documentation in your agent session to provide the correct API docs for code generation.
 
+### Governance & Security MCPs
+
+- [SidClaw](https://github.com/sidclawhq/platform) - Governance proxy for MCP servers. Wraps any upstream MCP server with policy evaluation, human approval workflows, and hash-chain audit trails. Configure via `.mcp.json` with zero code changes. Apache 2.0.
+
 ### Cloud MCPs
 
 - [Azure MCP](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md) - Azure MCP Server supercharges your agents with Azure context across different Azure services.


### PR DESCRIPTION
## Add SidClaw to MCPs section

Adds [SidClaw](https://github.com/sidclawhq/platform) as a governance MCP server under a new "Governance & Security MCPs" subsection.

**What it does:**
SidClaw is an MCP governance proxy that wraps any upstream MCP server with policy evaluation, human approval workflows, and hash-chain audit trails. Configure it in `.mcp.json` with zero code changes to Copilot or the upstream server.

**Why it fits this list:**
- Works as an MCP server that GitHub Copilot agents can use
- Adds access control and approval workflows to any MCP tool
- Relevant to any team using Copilot with MCP servers in production
- Apache 2.0 licensed, open source

**Links:**
- GitHub: https://github.com/sidclawhq/platform
- Docs: https://docs.sidclaw.com