### PR TITLE
Add Google Drive – Memyard to Documents skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Agent Skills are portable, [open standard](https://agentskills.io/home), version
 - [pdf](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/documents/pdf/README.md) - PDF manipulation toolkit for extracting text and tables, creating new PDFs, merging/splitting documents, and handling forms.
 - [pptx](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/documents/pptx/README.md) - Presentation creation, editing, and analysis.
 - [xlsx](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/documents/xlsx/README.md) - Spreadsheet creation, editing, and analysis with support for formulas, formatting, data analysis, and visualization.
+- [google-drive-memyard](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/documents/google-drive-memyard/README.md) - Create and edit Google Docs and Sheets without sign-in. Documents hosted on Memyard with shareable links.
 
 ### Cloud
 

--- a/skills/documents/google-drive-memyard/README.md
+++ b/skills/documents/google-drive-memyard/README.md
@@ -1,0 +1,1 @@
+Due to the skill requiring network access to the Memyard API, the skill can't be added directly. Reference [google-drive-memyard](https://github.com/zagmoai/public-google-drive/blob/main/SKILL.md) for skill.


### PR DESCRIPTION
Adds Google Drive – Memyard to the Documents section under Agent Skills.

Create and edit Google Docs and Sheets without sign-in. Documents hosted on Memyard with shareable links. No API keys or OAuth required.

- **GitHub:** https://github.com/zagmoai/public-google-drive
- **License:** MIT