### PR TITLE
Add Bernstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 ## Contents
 
+- [Bernstein](https://github.com/chernistry/bernstein) - Multi-agent orchestrator for AI coding agents. 21 adapters including Claude Code, Codex, Gemini CLI. Deterministic scheduling, quality gates.
 - [Why Copilot Agents](#why-copilot-agents)
 - [Instructions](#instructions)
   - [Boilerplates & Templates](#boilerplates--templates)


### PR DESCRIPTION
Adds [Bernstein](https://github.com/chernistry/bernstein) — open-source multi-agent orchestrator for AI coding agents. 21 adapters, deterministic scheduling, git worktree isolation, quality gates. Apache 2.0.