### PR TITLE
Add NotHumanSearch and AI Dev Jobs MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,13 @@ This section highlights useful MCP servers you can add to your Copilot setup to 
 - [Sequential Thinking](https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking) - Break down complex problems into structured steps.
 - [GitHub](https://github.com/github/github-mcp-server) - Allow your agent access to repository and workflow management.
 - [Time](https://github.com/modelcontextprotocol/servers/blob/main/src/time) - Enables agents to get current time information and perform timezone conversions using IANA timezone names, with automatic system timezone detection.
+- [NotHumanSearch](https://nothumansearch.ai/mcp) - Search an index of 8,600+ agent-friendly sites (MCP servers, APIs with llms.txt/OpenAPI, structured endpoints) filtered for real agent signals.
 
 ### Development MCPs
 
 - [Playwright](https://github.com/microsoft/playwright-mcp) - Playwright MCP to automate browser interactions, test web pages and work with Playwright tests.
 - [Context7](https://github.com/upstash/context7) - Inject version-specific code documentation in your agent session to provide the correct API docs for code generation.
+- [AI Dev Jobs](https://aidevboard.com/mcp) - Search 8,400+ AI/ML engineering jobs across 489 companies with tools for search_jobs, get_job, list_companies, and get_stats.
 
 ### Cloud MCPs
 


### PR DESCRIPTION
## Summary

Adds two production MCP servers to the MCPs section:

- **NotHumanSearch** (General MCPs) - Searchable index of 8,600+ agent-friendly sites filtered for real agent signals (llms.txt, OpenAPI, ai-plugin.json, MCP endpoints). Useful for agents that need to discover other agent-consumable APIs and tools.
- **AI Dev Jobs** (Development MCPs) - 8,400+ AI/ML engineering jobs aggregated across 489 companies. Tools: `search_jobs`, `get_job`, `list_companies`, `get_stats`. Useful for developer-focused Copilot workflows around job discovery and market research.

Both servers are live HTTPS JSON-RPC endpoints (no install step), published in the official MCP registry, and follow the same pattern as existing entries like GitHub MCP and Context7.

## Test plan

- [x] Entries alphabetized within their respective subsections where natural
- [x] Links resolve (both `/mcp` endpoints return JSON-RPC-ready responses)
- [x] Descriptions match the concise style of surrounding entries
- [x] No duplicates or existing entries touched