### PR TITLE
Add Bernstein

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 
 ## Contents
 
+- [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) - Multi-agent orchestrator for AI coding agents. 21 adapters including Claude Code, Codex, Gemini CLI. Deterministic scheduling, quality gates.
 - [Why Copilot Agents](#why-copilot-agents)
 - [Instructions](#instructions)
   - [Boilerplates & Templates](#boilerplates--templates)


### PR DESCRIPTION
Re-opens #42 with the canonical `https://github.com/sipyourdrink-ltd/bernstein` URL after the project transferred from my personal account to the @sipyourdrink-ltd organization. Same content as the previous PR, only the GitHub URL was updated.