### PR TITLE
Add KubeStellar Console to Cloud MCPs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ This section highlights useful MCP servers you can add to your Copilot setup to 
 - [Azure MCP](https://github.com/microsoft/mcp/blob/main/servers/Azure.Mcp.Server/README.md) - Azure MCP Server supercharges your agents with Azure context across different Azure services.
 - [AWS Documentation](https://github.com/awslabs/mcp/tree/main/src/aws-documentation-mcp-server) - Agent tools to access AWS documentation, search for content, and get recommendations.
 - [gcloud](https://github.com/googleapis/gcloud-mcp) - Agent tools to interact with the Google Cloud environment using the gcloud CLI.
+- [KubeStellar Console](https://github.com/kubestellar/console) - MCP server bridging AI agents to multi-cluster Kubernetes environments for cluster management, pod inspection, and real-time observability.
 
 ## How to Use
 


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Cloud MCPs section.

KubeStellar Console includes **kc-agent**, an MCP server that bridges AI coding agents (GitHub Copilot, Claude, Codex) to multi-cluster Kubernetes environments. It provides tools for:

- Cluster management and pod inspection
- Log retrieval and real-time observability
- Kubernetes resource queries across multiple clusters

KubeStellar is a [CNCF Sandbox project](https://www.cncf.io/projects/kubestellar/).