### PR TITLE
Add agenttrace session audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Agent Skills are portable, [open standard](https://agentskills.io/home), version
 
 ### Development
 
+- [agenttrace Session Audit](https://github.com/Code-and-Sorts/awesome-copilot-agents/tree/main/skills/development/agenttrace-session-audit/SKILL.md) - Audit local AI coding-agent sessions for token/cost usage, tool failures, latency, anomalies, health, diffs, and CI gates.
 - [Playwright CLI](https://github.com/microsoft/playwright-cli/blob/main/skills/playwright-cli/SKILL.md) - Automate browser interactions, test web pages and work with Playwright tests.
 - [Frontend Design](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) - Create distinctive, production-grade frontend interfaces with high design quality.
 - [Webapp Testing](https://github.com/anthropics/skills/blob/main/skills/webapp-testing/SKILL.md) - Toolkit for interacting with and testing local web applications using Playwright.

--- a/skills/development/agenttrace-session-audit/SKILL.md
+++ b/skills/development/agenttrace-session-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agenttrace-session-audit
-description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
+description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Qwen Code, Cline, Aider, Cursor exports, OpenCode, OpenClaw, Pi, Kimi CLI, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
 license: MIT
 metadata:
   short-description: Audit AI agent session health

--- a/skills/development/agenttrace-session-audit/SKILL.md
+++ b/skills/development/agenttrace-session-audit/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: agenttrace-session-audit
+description: Audit local AI coding-agent sessions with agenttrace. Use when the user asks to inspect Claude Code, Codex CLI, Gemini CLI, Aider, Cursor, OpenCode, Kimi, Copilot-style, or generic JSON/JSONL sessions for cost, tokens, tool failures, latency, anomalies, health, diffs, or CI gates.
+license: MIT
+metadata:
+  short-description: Audit AI agent session health
+---
+
+# agenttrace Session Audit
+
+Use this skill when session logs need an operational read: spend, token burn, cache use, tool failures, retry loops, latency, health, anomalies, and CI gate readiness.
+
+## Workflow
+
+1. Prefer the installed `agenttrace` binary when it is available on `PATH`.
+2. If the binary is not available and the current directory is the `luoyuctl/agenttrace` repository, use `go run ./cmd/agenttrace`.
+3. Start with discovery unless the user gave a specific file or directory:
+
+```bash
+agenttrace --doctor
+agenttrace --overview
+```
+
+1. For a fast human report, use Markdown:
+
+```bash
+agenttrace --overview -f markdown -o agenttrace-overview.md
+```
+
+1. For automation or CI, use JSON or health gates:
+
+```bash
+agenttrace --overview -f json -o agenttrace-overview.json
+agenttrace --overview --fail-under-health 80 --fail-on-critical --max-tool-fail-rate 15
+```
+
+1. For a single recent session:
+
+```bash
+agenttrace --latest
+agenttrace --latest -f json
+```
+
+1. For a specific export or session directory:
+
+```bash
+agenttrace path/to/session-or-export.json
+agenttrace --overview -d path/to/session-dir
+```
+
+## Report Focus
+
+- Lead with the highest-risk sessions and the reason they matter.
+- Call out token/cost waste, repeated tool failures, retry loops, long gaps, and low health scores.
+- When proposing a CI gate, include the exact `agenttrace` command and threshold.
+- If no sessions are detected, run `agenttrace --doctor` and report the detected agent directories and next step.
+
+## Guardrails
+
+- Treat prompts, code, and session contents as local/private data. Do not upload logs to external services.
+- Do not invent metrics. If a parser cannot infer cost, model, or latency, say which field is missing.
+- Do not overwrite user reports unless the user asked for that output path.


### PR DESCRIPTION
## Summary
- Add an agenttrace Session Audit skill under Agent Skills / Development.
- Update README links for the new skill.
- Keep current lint tooling green by disabling MD060 for existing skills tables and trimming three pre-existing no-repeat descriptions.

## Validation
- npx --yes markdownlint-cli2 "**/*.md" "#node_modules" ✅
- git diff --check ✅

Note: local awesome-lint still reports GitHub topic checks against the fork context, while the upstream repo already has the required awesome/awesome-list topics.