### PR TITLE
feat: add TWZRD Agent Intel to Web3 & Agent Identity MCPs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ This section highlights useful MCP servers you can add to your Copilot setup to 
 - [gcloud](https://github.com/googleapis/gcloud-mcp) - Agent tools to interact with the Google Cloud environment using the gcloud CLI.
 - [KubeStellar Console](https://github.com/kubestellar/console) - MCP server bridging AI agents to multi-cluster Kubernetes environments for cluster management, pod inspection, and real-time observability.
 
+### Web3 & Agent Identity MCPs
+
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring and x402 payment verification for AI agents on Solana; zero-install remote MCP (`https://intel.twzrd.xyz/mcp`).
+
 ## How to Use
 
 ### Setup Copilot in VSCode


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the MCPs section under a new **Web3 & Agent Identity MCPs** subsection.

TWZRD Agent Intel is a zero-install remote MCP server providing trust scoring and x402 payment verification for AI agents operating on Solana. It's the trust layer for agent-to-agent interactions in the emerging agentic economy.

**MCP config (no install required):**
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

**Available tools (free):**
- `score_agent(wallet)` — returns trust score 0-100 for a Solana agent
- `resolve_agent(wallet)` — agent identity resolution
- `preflight_check(wallet)` — pre-transaction safety check
- `verify_trust_receipt(receipt)` — verify x402 payment receipt

PyPI: `pip install twzrd-agent-intel`